### PR TITLE
引入MediaInfo库检测音频轨道，并修复处理含有旋转元信息的视频时输出文件旋转的问题

### DIFF
--- a/VideoSlim/VideoSlim.py
+++ b/VideoSlim/VideoSlim.py
@@ -8,12 +8,12 @@ from tkinter import *
 import webbrowser
 import windnd
 from tkinter import messagebox
-from moviepy.editor import *
 import requests
 import os
 import threading
 import subprocess
 from subprocess import CREATE_NO_WINDOW
+from pymediainfo import MediaInfo
 import json
 
 extention_lists = [".mp4", ".mkv", ".mov", ".avi"]
@@ -289,10 +289,12 @@ class DragDropApp():
 
             save_out_name = self.GetSaveOutFileName(file_name)
 
+            # 读取视频元信息
+            media_info = MediaInfo.parse(file_name)
+
             # 判断视频是否拥有音频轨道
-            video = VideoFileClip(file_name)
             commands = []
-            if video.audio is None or delete_audio:
+            if len(media_info.audio_tracks) == 0 or delete_audio:
                 logging.info("视频没有音频轨道")
 
                 command1 = rf'.\tools\x264_64-8bit.exe --crf {config.X264.crf} --preset {config.X264.preset} -I {config.X264.I} -r {config.X264.r} -b {config.X264.b} --me umh -i 1 --scenecut 60 -f 1:1 --qcomp 0.5 --psy-rd 0.3:0 --aq-mode 2 --aq-strength 0.8 -o "{save_out_name}"  "{file_name}"'
@@ -338,8 +340,6 @@ class DragDropApp():
                 if os.path.exists("./old_vtemp.mp4"):
                     os.remove("./old_vtemp.mp4")
             self.queue.put({"action": "finish", "index": index, "filename": file_name})
-
-            video.close()
 
         self.queue.put({"action": "finish_all", "total": len(lines)})
 
@@ -482,7 +482,7 @@ class DragDropApp():
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO,
-                        filename='log',
+                        filename='log.txt',
                         filemode='w',
                         format='%(asctime)s - %(levelname)s - %(message)s')
     root = Tk()


### PR DESCRIPTION
安卓拍摄的视频会附带旋转信息在视频元信息中。
例如 `ffmpeg -i video.mp4 -hide_banner` 查看视频的信息。
```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'video.mp4':
  Metadata:
    major_brand     : mp42
    minor_version   : 0
    compatible_brands: isommp42
    creation_time   : 2024-11-08T09:05:46.000000Z
    com.android.version: 13
    com.android.capture.fps: 60.000000
  Duration: 00:00:20.32, start: 0.000000, bitrate: 10410 kb/s
  Stream #0:0[0x1](eng): Video: hevc (Main) (hvc1 / 0x31637668), yuv420p(tv, bt709), 1920x1080, 10002 kb/s, 60.02 fps, 59.94 tbr, 90k tbn (default)
    Metadata:
      creation_time   : 2024-11-08T09:05:46.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
    Side data:
      displaymatrix: rotation of -90.00 degrees
  Stream #0:1[0x2](eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 256 kb/s (default)
    Metadata:
      creation_time   : 2024-11-08T09:05:46.000000Z
      handler_name    : SoundHandle
      vendor_id       : [0][0][0][0]
```
其中可以看见是视频流的信息，里面有视频分辨率和视频的旋转信息
```
  Stream #0:0[0x1](eng): Video: hevc (Main) (hvc1 / 0x31637668), yuv420p(tv, bt709), 1920x1080, 10002 kb/s, 60.02 fps, 59.94 tbr, 90k tbn (default)
    Metadata:
      creation_time   : 2024-11-08T09:05:46.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
    Side data:
      displaymatrix: rotation of -90.00 degrees
```
发现视频实际上是 1920x1080（其实是横屏的），但是为什么播放器播放的时候是竖屏的呢？这是因为播放器读取到了 `displaymatrix: rotation of -90.00 degrees` 这一条因此对视频进行了旋转，变成1080x1920的竖屏视频。

ffmpeg对视频进行处理的时候会自动消除这个信息并把视频按相应信息进行旋转，但是x264不会（似乎是直接丢掉了这条信息），所以用x264处理手机拍摄的视频会产生横屏变竖屏、竖屏变横屏的问题。

解决方法是使用 `ffmpeg -i video.mp4 output.mp4` 让 ffmpeg 对视频处理消去旋转信息后再让x264处理。